### PR TITLE
Update agents review-sets, requirements-linking, AAA-comments

### DIFF
--- a/.github/agents/quality.agent.md
+++ b/.github/agents/quality.agent.md
@@ -86,7 +86,7 @@ This ensures orchestrators properly halt workflows when quality gates fail.
 
 ## Review Management Compliance: (PASS|FAIL|N/A)
 
-- Were review-sets updated to include new/modified files? (PASS|FAIL|N/A) - [Evidence]
+- Were review-sets updated for structural changes (new/deleted systems, subsystems, or units)? (PASS|FAIL|N/A) - [Evidence]
 - Do file patterns follow include-then-exclude approach? (PASS|FAIL|N/A) - [Evidence]
 - Is review scope appropriate for change magnitude? (PASS|FAIL|N/A) - [Evidence]
 - Was ReviewMark tooling executed and passing? (PASS|FAIL|N/A) - [Evidence]

--- a/.github/standards/csharp-testing.md
+++ b/.github/standards/csharp-testing.md
@@ -13,14 +13,11 @@ requirements.
 [TestMethod]
 public void ServiceName_MethodName_Scenario_ExpectedBehavior()
 {
-    // Arrange - (description)
-    // TODO: Set up test data, mocks, and system under test.
+    // Arrange: description of setup (omit if nothing to set up)
 
-    // Act - (description)
-    // TODO: Execute the action being tested
+    // Act: description of action (can combine with Assert when action occurs within assertion)
 
-    // Assert - (description)
-    // TODO: Verify expected outcomes and interactions
+    // Assert: description of verification
 }
 ```
 

--- a/.github/standards/reqstream-usage.md
+++ b/.github/standards/reqstream-usage.md
@@ -58,6 +58,17 @@ only flow downward in the hierarchy to maintain clear traceability:
 This prevents circular dependencies and ensures clear hierarchical relationships
 for compliance auditing.
 
+# Test Linkage Hierarchy
+
+Requirements MUST link to tests at their own level to maintain proper test scope:
+
+- **System requirements** → link ONLY to system-level integration tests
+- **Subsystem requirements** → link ONLY to subsystem-level tests
+- **Unit requirements** → link ONLY to unit-level tests
+
+Lower-level tests validate implementation details, while higher-level requirements
+are validated through integration behavior at their architectural level.
+
 # Requirements File Format
 
 ```yaml

--- a/.github/standards/reviewmark-usage.md
+++ b/.github/standards/reviewmark-usage.md
@@ -29,7 +29,7 @@ Configure reviews in `.reviewmark.yaml` at repository root:
 needs-review:
   # Include source code (adjust file extensions for your repo)
   - "**/*.cs"           # C# source files
-  - "**/*.cpp"          # C++ source files  
+  - "**/*.cpp"          # C++ source files
   - "**/*.hpp"          # C++ header files
   - "!**/bin/**"        # Generated source in build outputs
   - "!**/obj/**"        # Generated source in build intermediates
@@ -48,72 +48,115 @@ evidence-source:
   type: none
 ```
 
+# Review-Set Design Principles
+
+When constructing review-sets, follow these principles to maintain manageable scope and effective compliance evidence:
+
+- **Hierarchical Scope**: Higher-level reviews exclude lower-level implementation details, relying instead on design
+  documents to describe what components they use. System reviews exclude subsystem/unit details, subsystem reviews
+  exclude unit source code, only unit reviews include actual implementation.
+- **Single Focus**: Each review-set proves one specific compliance question (user promises, system architecture,
+  design consistency, etc.)
+- **Context Management**: Keep file counts manageable to prevent context overflow while maintaining complete coverage
+  through the hierarchy
+
 # Review-Set Organization
 
-Organize review-sets using standard patterns to ensure comprehensive coverage
-and consistent review processes:
+Organize review-sets using these standard patterns to ensure comprehensive coverage
+while keeping each review manageable in scope:
 
-## [System]-Architecture Review (one per system)
+**Note**: File path patterns shown below use C# naming conventions (PascalCase, `.cs` extensions).
+Other languages should adapt these patterns to their conventions (e.g., C++ might use
+`snake_case` with `.cpp`/`.hpp` extensions).
+
+## `Purpose` Review (only one per repository)
+
+Reviews user-facing capabilities and system promises:
+
+- **Purpose**: Proves that the systems provide the capabilities the user is being told about
+- **Scope**: Excludes subsystem and unit files, relying on system-level design documents
+  to describe what subsystems and units they use
+- **File Path Patterns**:
+  - README: `README.md`
+  - User guide: `docs/user_guide/**/*.md`
+  - System requirements: `docs/reqstream/{system-name}/{system-name}.yaml`
+  - Design introduction: `docs/design/introduction.md`
+  - System design: `docs/design/{system-name}/{system-name}.md`
+
+## `[System]-Architecture` Review (one per system)
 
 Reviews system architecture and operational validation:
 
-- **Files**: System requirements (`docs/reqstream/{system-name}/{system-name}.yaml`), design introduction
-  (`docs/design/introduction.md`), system design (`docs/design/{system-name}/{system-name}.md`),
-  integration tests
-- **Purpose**: Validates system operates as designed and meets overall requirements
-- **Example**: `SomeSystem-Architecture`
+- **Purpose**: Proves that the system is designed and tested to satisfy its requirements
+- **Scope**: Excludes subsystem and unit files, relying on system-level design to describe
+  what subsystems and units it uses
+- **File Path Patterns**:
+  - System requirements: `docs/reqstream/{system-name}/{system-name}.yaml`
+  - Design introduction: `docs/design/introduction.md`
+  - System design: `docs/design/{system-name}/{system-name}.md`
+  - System integration tests: `test/{SystemName}.Tests/{SystemName}Tests.cs`
 
-## [System]-Design Review
+## `[System]-Design` Review (one per system)
 
 Reviews architectural and design consistency:
 
-- **Files**: System requirements, platform requirements, all design documents under `docs/design/`
-- **Purpose**: Ensures design completeness and architectural coherence
-- **Example**: `SomeSystem-Design`
+- **Purpose**: Proves the system design is consistent and complete
+- **Scope**: Only brings in top-level requirements and relies on brevity of design documentation
+- **File Path Patterns**:
+  - System requirements: `docs/reqstream/{system-name}/{system-name}.yaml`
+  - Platform requirements: `docs/reqstream/{system-name}/platform-requirements.yaml`
+  - Design introduction: `docs/design/introduction.md`
+  - System design files: `docs/design/{system-name}/**/*.md`
 
-## [System]-AllRequirements Review
+## `[System]-AllRequirements` Review (one per system)
 
 Reviews requirements quality and traceability:
 
-- **Files**: All requirement files including root `requirements.yaml` and all files under `docs/reqstream/{system-name}/`
-- **Purpose**: Validates requirements structure, IDs, justifications, and test linkage
-- **Example**: `SomeSystem-AllRequirements`
+- **Purpose**: Proves the requirements are consistent and complete
+- **Scope**: Only brings in requirements files to keep review manageable
+- **File Path Patterns**:
+  - Root requirements: `requirements.yaml`
+  - System requirements: `docs/reqstream/{system-name}/**/*.yaml`
+  - OTS requirements: `docs/reqstream/ots/**/*.yaml` (if applicable)
 
-## [System]-[Subsystem] Review
+## `[System]-[Subsystem]` Review (one per subsystem)
 
 Reviews subsystem architecture and interfaces:
 
-- **Files**: Subsystem requirements, design documents, integration tests (usually no source code)
-- **Purpose**: Validates subsystem behavior and interface compliance
-- **File Path Pattern**:
+- **Purpose**: Proves that the subsystem is designed and tested to satisfy its requirements
+- **Scope**: Excludes units under the subsystem, relying on subsystem design to describe
+  what units it uses
+- **File Path Patterns**:
   - Requirements: `docs/reqstream/{system-name}/{subsystem-name}/{subsystem-name}.yaml`
   - Design: `docs/design/{system-name}/{subsystem-name}/{subsystem-name}.md`
-  - Tests: `test/{SystemName}.Tests/{SubsystemName}/{SubsystemName}*` or similar
-- **Example**: `SomeSystem-Authentication`, `SomeSystem-DataLayer`
+  - Tests: `test/{SystemName}.Tests/{SubsystemName}/{SubsystemName}Tests.cs`
 
-## [System]-[Subsystem]-[Unit] Review
+## `[System]-[Subsystem]-[Unit]` Review (one per unit)
 
 Reviews individual software unit implementation:
 
-- **Files**: Unit requirements, design documents, source code, unit tests
-- **Purpose**: Validates unit meets requirements and is properly implemented
-- **File Path Pattern**:
-  - Requirements: `docs/reqstream/{system-name}/{subsystem-name}/{unit-name}.yaml` or `docs/reqstream/{system-name}/{unit-name}.yaml`
-  - Design: `docs/design/{system-name}/{subsystem-name}/{unit-name}.md` or `docs/design/{system-name}/{unit-name}.md`
-  - Source: `src/{SystemName}/{SubsystemName}/{UnitName}.cs`
-  - Tests: `test/{SystemName}.Tests/{SubsystemName}/{UnitName}Tests.cs`
-- **Example**: `SomeSystem-Authentication-PasswordValidator`, `SomeSystem-DataLayer-ConfigParser`
+- **Purpose**: Proves the unit is designed, implemented, and tested to satisfy its requirements
+- **Scope**: Complete unit review including all artifacts
+- **File Path Patterns**:
+  - Requirements: `docs/reqstream/{system-name}/{subsystem-name}/{unit-name}.yaml` or
+    `docs/reqstream/{system-name}/{unit-name}.yaml`
+  - Design: `docs/design/{system-name}/{subsystem-name}/{unit-name}.md` or
+    `docs/design/{system-name}/{unit-name}.md`
+  - Source: `src/{SystemName}/{SubsystemName}/{UnitName}.cs` or `src/{SystemName}/{UnitName}.cs`
+  - Tests: `test/{SystemName}.Tests/{SubsystemName}/{UnitName}Tests.cs` or
+    `test/{SystemName}.Tests/{UnitName}Tests.cs`
 
 # Quality Checks
 
 Before submitting ReviewMark configuration, verify:
 
 - [ ] `.reviewmark.yaml` exists at repository root with proper structure
-- [ ] `needs-review` patterns cover requirements, design, code, and tests with proper exclusions
-- [ ] Each review-set has unique `id` and groups architecturally related files
+- [ ] Review-set organization follows the standard hierarchy patterns
+- [ ] Purpose review-set includes README.md, user guide, system requirements, design introduction, and system design files
+- [ ] System-level reviews follow hierarchical scope principle (exclude subsystem/unit details)
+- [ ] Subsystem reviews follow hierarchical scope principle (exclude unit source code)
+- [ ] Only unit reviews include actual source code files
+- [ ] Each review-set focuses on a single compliance question (single focus principle)
 - [ ] File patterns use correct glob syntax and match intended files
-- [ ] File paths reflect current naming conventions (kebab-case design/requirements folders, PascalCase source folders)
+- [ ] Review-set file counts remain manageable (context management principle)
 - [ ] Evidence source properly configured (`none` for dev, `url` for production)
-- [ ] Environment variables used for credentials (never hardcoded)
-- [ ] Generated documents accessible for compliance auditing
-- [ ] Review-set organization follows standard patterns ([System]-[Subsystem], [System]-Design, etc.)

--- a/.reviewmark.yaml
+++ b/.reviewmark.yaml
@@ -23,92 +23,100 @@ evidence-source:
   type: url
   location: https://raw.githubusercontent.com/demaconsulting/TemplateDotNetTool/reviews/index.json
 
-# Review sets grouping files by logical unit of review.
-# Each review-set groups requirements, source, and tests for a coherent software unit
-# so that an AI-assisted review can verify consistency across the full evidence chain.
+# Review sets following standardized patterns for hierarchical compliance coverage
 reviews:
-  # Software unit reviews - one per unit
-  - id: TemplateTool-Program
-    title: Review of Template DotNet Tool Program Unit
+  # Purpose Review (only one per repository)
+  - id: Purpose
+    title: Review of user-facing capabilities and system promises
     paths:
-      - "docs/reqstream/template-dot-net-tool/program.yaml"              # requirements
-      - "docs/design/template-dot-net-tool/program.md"                   # design
-      - "src/**/Program.cs"                                              # implementation
-      - "test/**/ProgramTests.cs"                                        # unit tests
+      - "README.md"
+      - "docs/user_guide/**/*.md"
+      - "docs/reqstream/template-dot-net-tool/template-dot-net-tool.yaml"
+      - "docs/design/introduction.md"
+      - "docs/design/template-dot-net-tool/template-dot-net-tool.md"
 
-  - id: TemplateTool-Cli-Context
-    title: Review of Template DotNet Tool Context Unit
-    paths:
-      - "docs/reqstream/template-dot-net-tool/cli/context.yaml"          # requirements
-      - "docs/design/template-dot-net-tool/cli/context.md"               # design
-      - "src/**/Cli/Context.cs"                                          # implementation
-      - "test/**/Cli/ContextTests.cs"                                    # unit tests
-
-  - id: TemplateTool-SelfTest-Validation
-    title: Review of Template DotNet Tool Validation Unit
-    paths:
-      - "docs/reqstream/template-dot-net-tool/self-test/validation.yaml"  # requirements
-      - "docs/design/template-dot-net-tool/self-test/validation.md"      # design
-      - "src/**/SelfTest/Validation.cs"                                  # implementation
-      - "test/**/SelfTest/ValidationTests.cs"                            # unit tests
-
-  - id: TemplateTool-Utilities-PathHelpers
-    title: Review of Template DotNet Tool PathHelpers Unit
-    paths:
-      - "docs/reqstream/template-dot-net-tool/utilities/path-helpers.yaml"  # requirements
-      - "docs/design/template-dot-net-tool/utilities/path-helpers.md"      # design
-      - "src/**/Utilities/PathHelpers.cs"                                   # implementation
-      - "test/**/Utilities/PathHelpersTests.cs"                             # unit tests
-
-  # Subsystem reviews
-  - id: TemplateTool-Cli
-    title: Review of Template DotNet Tool Cli subsystem (command-line interface)
-    paths:
-      - "docs/reqstream/template-dot-net-tool/cli/cli.yaml"              # subsystem requirements
-      - "docs/design/template-dot-net-tool/cli/cli.md"                   # subsystem design
-      - "docs/design/template-dot-net-tool/cli/context.md"               # Context unit design
-      - "docs/design/template-dot-net-tool/program.md"                   # Program unit design
-
-  - id: TemplateTool-SelfTest
-    title: Review of Template DotNet Tool SelfTest subsystem (self-validation)
-    paths:
-      - "docs/reqstream/template-dot-net-tool/self-test/self-test.yaml"  # subsystem requirements
-      - "docs/design/template-dot-net-tool/self-test/self-test.md"       # subsystem design
-      - "docs/design/template-dot-net-tool/self-test/validation.md"      # Validation unit design
-
-  - id: TemplateTool-Utilities
-    title: Review of Template DotNet Tool Utilities subsystem (shared utilities)
-    paths:
-      - "docs/reqstream/template-dot-net-tool/utilities/utilities.yaml"  # subsystem requirements
-      - "docs/design/template-dot-net-tool/utilities/utilities.md"       # subsystem design
-      - "docs/design/template-dot-net-tool/utilities/path-helpers.md"    # PathHelpers unit design
-
-  # Architecture review - covers system-level behavior validated through integration tests
+  # TemplateTool-Architecture Review (one per system)
   - id: TemplateTool-Architecture
-    title: Review of Template DotNet Tool system-level behavior and integration
+    title: Review of Template DotNet Tool system architecture and operational validation
     paths:
-      - "README.md"                                                          # project readme
-      - "docs/reqstream/template-dot-net-tool/template-dot-net-tool.yaml"  # system requirements
-      - "docs/reqstream/template-dot-net-tool/platform-requirements.yaml"  # platform requirements
-      - "docs/design/introduction.md"                                       # design introduction and architecture
-      - "docs/design/template-dot-net-tool/template-dot-net-tool.md"       # system design
-      - "test/**/IntegrationTests.cs"                                       # integration tests
-      - "test/**/Runner.cs"                                                 # test infrastructure
-      - "test/**/AssemblyInfo.cs"                                           # test infrastructure
+      - "docs/reqstream/template-dot-net-tool/template-dot-net-tool.yaml"
+      - "docs/design/introduction.md"
+      - "docs/design/template-dot-net-tool/template-dot-net-tool.md"
+      - "test/**/IntegrationTests.cs"
 
+  # TemplateTool-Design Review (one per system)
   - id: TemplateTool-Design
-    title: Review of Template DotNet Tool Software Design Document
+    title: Review of Template DotNet Tool architectural and design consistency
     paths:
-      - "docs/design/**/*.md"                                              # all design documents
+      - "docs/reqstream/template-dot-net-tool/template-dot-net-tool.yaml"
+      - "docs/reqstream/template-dot-net-tool/platform-requirements.yaml"
+      - "docs/design/introduction.md"
+      - "docs/design/template-dot-net-tool/**/*.md"
 
-  - id: TemplateTool-UserGuide
-    title: Review of Template DotNet Tool User Guide Document
-    paths:
-      - "docs/user_guide/**/*.md"                                          # all user guide documents
-
-  # All-requirements review
+  # TemplateTool-AllRequirements Review (one per system)
   - id: TemplateTool-AllRequirements
-    title: Review of all Template DotNet Tool requirements files
+    title: Review of Template DotNet Tool requirements quality and traceability
     paths:
-      - "requirements.yaml"                                               # root requirements file
-      - "docs/reqstream/**/*.yaml"                                        # all requirements files
+      - "requirements.yaml"
+      - "docs/reqstream/template-dot-net-tool/**/*.yaml"
+      - "docs/reqstream/ots/**/*.yaml"
+
+  # TemplateTool-Cli Review (one per subsystem)
+  - id: TemplateTool-Cli
+    title: Review of Template DotNet Tool Cli subsystem architecture and interfaces
+    paths:
+      - "docs/reqstream/template-dot-net-tool/cli/cli.yaml"
+      - "docs/design/template-dot-net-tool/cli/cli.md"
+      - "test/**/Cli/CliSubsystemTests.cs"
+
+  # TemplateTool-SelfTest Review (one per subsystem)
+  - id: TemplateTool-SelfTest
+    title: Review of Template DotNet Tool SelfTest subsystem architecture and interfaces
+    paths:
+      - "docs/reqstream/template-dot-net-tool/self-test/self-test.yaml"
+      - "docs/design/template-dot-net-tool/self-test/self-test.md"
+      - "test/**/SelfTest/SelfTestSubsystemTests.cs"
+
+  # TemplateTool-Utilities Review (one per subsystem)
+  - id: TemplateTool-Utilities
+    title: Review of Template DotNet Tool Utilities subsystem architecture and interfaces
+    paths:
+      - "docs/reqstream/template-dot-net-tool/utilities/utilities.yaml"
+      - "docs/design/template-dot-net-tool/utilities/utilities.md"
+      - "test/**/Utilities/UtilitiesSubsystemTests.cs"
+
+  # TemplateTool-Cli-Context Review (one per unit)
+  - id: TemplateTool-Cli-Context
+    title: Review of Template DotNet Tool Context unit implementation
+    paths:
+      - "docs/reqstream/template-dot-net-tool/cli/context.yaml"
+      - "docs/design/template-dot-net-tool/cli/context.md"
+      - "src/**/Cli/Context.cs"
+      - "test/**/Cli/ContextTests.cs"
+
+  # TemplateTool-Program Review (one per unit)
+  - id: TemplateTool-Program
+    title: Review of Template DotNet Tool Program unit implementation
+    paths:
+      - "docs/reqstream/template-dot-net-tool/program.yaml"
+      - "docs/design/template-dot-net-tool/program.md"
+      - "src/**/Program.cs"
+      - "test/**/ProgramTests.cs"
+
+  # TemplateTool-SelfTest-Validation Review (one per unit)
+  - id: TemplateTool-SelfTest-Validation
+    title: Review of Template DotNet Tool Validation unit implementation
+    paths:
+      - "docs/reqstream/template-dot-net-tool/self-test/validation.yaml"
+      - "docs/design/template-dot-net-tool/self-test/validation.md"
+      - "src/**/SelfTest/Validation.cs"
+      - "test/**/SelfTest/ValidationTests.cs"
+
+  # TemplateTool-Utilities-PathHelpers Review (one per unit)
+  - id: TemplateTool-Utilities-PathHelpers
+    title: Review of Template DotNet Tool PathHelpers unit implementation
+    paths:
+      - "docs/reqstream/template-dot-net-tool/utilities/path-helpers.yaml"
+      - "docs/design/template-dot-net-tool/utilities/path-helpers.md"
+      - "src/**/Utilities/PathHelpers.cs"
+      - "test/**/Utilities/PathHelpersTests.cs"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,7 @@ Delegate to specialized agents only for specific scenarios:
 
 1. **Markdown Auto-fix**: `npx markdownlint-cli2 --fix **/*.md` (fixes most markdown issues except line length)
 2. **Dotnet Auto-fix**: `dotnet format` (reformats .NET languages)
-3. **Run full check**: `lint.bat` (Windows) or `lint.sh` (Unix)  
+3. **Run full check**: `lint.bat` (Windows) or `lint.sh` (Unix)
 4. **Fix remaining**: Address line length, spelling, YAML syntax manually
 5. **Verify clean**: Re-run until 0 errors before quality validation
 

--- a/docs/reqstream/template-dot-net-tool/cli/cli.yaml
+++ b/docs/reqstream/template-dot-net-tool/cli/cli.yaml
@@ -17,11 +17,10 @@ sections:
           all parsed flags and output channels so that the rest of the tool has a single,
           consistent entry point for CLI interaction.
         tests:
-          - Context_Create_NoArguments_ReturnsDefaultContext
-          - Context_Create_VersionFlag_SetsVersionTrue
-          - Context_Create_SilentFlag_SetsSilentTrue
-          - Context_Create_LogFlag_OpensLogFile
-          - Context_Create_UnknownArgument_ThrowsArgumentException
+          - CliSubsystem_VersionFlow_ContextAndProgram_DisplaysVersionAndExits
+          - CliSubsystem_HelpFlow_ContextAndProgram_DisplaysHelpAndExits
+          - CliSubsystem_ValidateFlow_ContextAndProgram_RunsValidationAndExits
+          - CliSubsystem_SilentFlow_ContextAndProgram_SuppressesOutput
 
       - id: Template-Cli-Version
         title: The Cli subsystem shall support -v and --version flags to signal version display.
@@ -29,11 +28,7 @@ sections:
           Users need to quickly identify the version of the tool they are using for
           troubleshooting and compatibility verification.
         tests:
-          - Context_Create_VersionFlag_SetsVersionTrue
-          - Context_Create_ShortVersionFlag_SetsVersionTrue
-          - Program_Run_WithVersionFlag_DisplaysVersionOnly
-          - Program_Version_ReturnsNonEmptyString
-          - IntegrationTest_VersionFlag_OutputsVersion
+          - CliSubsystem_VersionFlow_ContextAndProgram_DisplaysVersionAndExits
 
       - id: Template-Cli-Help
         title: The Cli subsystem shall support -?, -h, and --help flags to signal help display.
@@ -41,11 +36,7 @@ sections:
           Users need access to command-line usage documentation without requiring
           external resources.
         tests:
-          - Context_Create_HelpFlag_SetsHelpTrue
-          - Context_Create_ShortHelpFlag_H_SetsHelpTrue
-          - Context_Create_ShortHelpFlag_Question_SetsHelpTrue
-          - Program_Run_WithHelpFlag_DisplaysUsageInformation
-          - IntegrationTest_HelpFlag_OutputsUsageInformation
+          - CliSubsystem_HelpFlow_ContextAndProgram_DisplaysHelpAndExits
 
       - id: Template-Cli-Silent
         title: The Cli subsystem shall support --silent flag to suppress console output.
@@ -53,9 +44,7 @@ sections:
           Enables automated scripts and CI/CD pipelines to run the tool without
           cluttering output logs.
         tests:
-          - Context_Create_SilentFlag_SetsSilentTrue
-          - Context_WriteLine_Silent_DoesNotWriteToConsole
-          - IntegrationTest_SilentFlag_SuppressesOutput
+          - CliSubsystem_SilentFlow_ContextAndProgram_SuppressesOutput
 
       - id: Template-Cli-Validate
         title: The Cli subsystem shall support --validate flag to signal self-validation.
@@ -63,29 +52,21 @@ sections:
           Provides a built-in mechanism to verify the tool is functioning correctly
           in the deployment environment.
         tests:
-          - Context_Create_ValidateFlag_SetsValidateTrue
-          - Program_Run_WithValidateFlag_RunsValidation
-          - IntegrationTest_ValidateFlag_RunsValidation
+          - CliSubsystem_ValidateFlow_ContextAndProgram_RunsValidationAndExits
 
       - id: Template-Cli-Results
         title: The Cli subsystem shall support --results flag to specify a test results output file.
         justification: |
           Enables integration with CI/CD systems that expect standard test result formats.
         tests:
-          - Context_Create_ResultsFlag_SetsResultsFile
-          - Context_Create_ResultsFlag_WithoutValue_ThrowsArgumentException
-          - IntegrationTest_ValidateWithResults_GeneratesTrxFile
-          - IntegrationTest_ValidateWithResults_GeneratesJUnitFile
+          - CliSubsystem_ValidateFlow_ContextAndProgram_RunsValidationAndExits
 
       - id: Template-Cli-Log
         title: The Cli subsystem shall support --log flag to write output to a log file.
         justification: |
           Provides persistent logging for debugging and audit trails.
         tests:
-          - Context_Create_LogFlag_OpensLogFile
-          - Context_Create_LogFlag_WithoutValue_ThrowsArgumentException
-          - Context_WriteError_WritesToLogFile
-          - IntegrationTest_LogFlag_WritesOutputToFile
+          - CliSubsystem_VersionFlow_ContextAndProgram_DisplaysVersionAndExits
 
       - id: Template-Cli-ErrorOutput
         title: The Cli subsystem shall write error messages to stderr.
@@ -93,9 +74,7 @@ sections:
           Error messages must be written to stderr so they remain visible to the user
           without polluting stdout, which consumers may pipe or redirect for data capture.
         tests:
-          - Context_WriteError_NotSilent_WritesToConsole
-          - Context_WriteError_SetsErrorExitCode
-          - IntegrationTest_UnknownArgument_ReturnsError
+          - CliSubsystem_VersionFlow_ContextAndProgram_DisplaysVersionAndExits
 
       - id: Template-Cli-InvalidArgs
         title: The Cli subsystem shall reject unknown or malformed command-line arguments with a descriptive error.
@@ -103,10 +82,7 @@ sections:
           Providing clear feedback for invalid arguments helps users quickly correct
           mistakes and prevents silent misconfiguration.
         tests:
-          - Context_Create_UnknownArgument_ThrowsArgumentException
-          - Context_Create_LogFlag_WithoutValue_ThrowsArgumentException
-          - Context_Create_ResultsFlag_WithoutValue_ThrowsArgumentException
-          - IntegrationTest_UnknownArgument_ReturnsError
+          - CliSubsystem_VersionFlow_ContextAndProgram_DisplaysVersionAndExits
 
       - id: Template-Cli-ExitCode
         title: The Cli subsystem shall return a non-zero exit code on failure.
@@ -114,5 +90,4 @@ sections:
           Callers (scripts, CI/CD pipelines) must be able to detect failure conditions
           programmatically via the process exit code.
         tests:
-          - Context_WriteError_SetsErrorExitCode
-          - IntegrationTest_UnknownArgument_ReturnsError
+          - CliSubsystem_VersionFlow_ContextAndProgram_DisplaysVersionAndExits

--- a/docs/reqstream/template-dot-net-tool/cli/cli.yaml
+++ b/docs/reqstream/template-dot-net-tool/cli/cli.yaml
@@ -19,6 +19,8 @@ sections:
         tests:
           - CliSubsystem_VersionFlow_ContextAndProgram_DisplaysVersionAndExits
           - CliSubsystem_HelpFlow_ContextAndProgram_DisplaysHelpAndExits
+          - CliSubsystem_HelpFlow_ContextAndProgram_DisplaysHelpAndExits_WithShortQuestionFlag
+          - CliSubsystem_HelpFlow_ContextAndProgram_DisplaysHelpAndExits_WithShortHFlag
           - CliSubsystem_ValidateFlow_ContextAndProgram_RunsValidationAndExits
           - CliSubsystem_SilentFlow_ContextAndProgram_SuppressesOutput
 
@@ -37,6 +39,8 @@ sections:
           external resources.
         tests:
           - CliSubsystem_HelpFlow_ContextAndProgram_DisplaysHelpAndExits
+          - CliSubsystem_HelpFlow_ContextAndProgram_DisplaysHelpAndExits_WithShortQuestionFlag
+          - CliSubsystem_HelpFlow_ContextAndProgram_DisplaysHelpAndExits_WithShortHFlag
 
       - id: Template-Cli-Silent
         title: The Cli subsystem shall support --silent flag to suppress console output.

--- a/docs/reqstream/template-dot-net-tool/cli/cli.yaml
+++ b/docs/reqstream/template-dot-net-tool/cli/cli.yaml
@@ -59,14 +59,14 @@ sections:
         justification: |
           Enables integration with CI/CD systems that expect standard test result formats.
         tests:
-          - CliSubsystem_ValidateFlow_ContextAndProgram_RunsValidationAndExits
+          - CliSubsystem_ResultsFlow_ContextAndProgram_WritesResultsFile
 
       - id: Template-Cli-Log
         title: The Cli subsystem shall support --log flag to write output to a log file.
         justification: |
           Provides persistent logging for debugging and audit trails.
         tests:
-          - CliSubsystem_VersionFlow_ContextAndProgram_DisplaysVersionAndExits
+          - CliSubsystem_LogFlow_ContextAndProgram_WritesLogFile
 
       - id: Template-Cli-ErrorOutput
         title: The Cli subsystem shall write error messages to stderr.
@@ -74,7 +74,7 @@ sections:
           Error messages must be written to stderr so they remain visible to the user
           without polluting stdout, which consumers may pipe or redirect for data capture.
         tests:
-          - CliSubsystem_VersionFlow_ContextAndProgram_DisplaysVersionAndExits
+          - CliSubsystem_ErrorOutput_ContextAndProgram_WritesErrorToStderr
 
       - id: Template-Cli-InvalidArgs
         title: The Cli subsystem shall reject unknown or malformed command-line arguments with a descriptive error.
@@ -82,7 +82,7 @@ sections:
           Providing clear feedback for invalid arguments helps users quickly correct
           mistakes and prevents silent misconfiguration.
         tests:
-          - CliSubsystem_VersionFlow_ContextAndProgram_DisplaysVersionAndExits
+          - CliSubsystem_InvalidArgs_ContextAndProgram_RejectsUnknownArgumentsAndExitsNonZero
 
       - id: Template-Cli-ExitCode
         title: The Cli subsystem shall return a non-zero exit code on failure.
@@ -90,4 +90,4 @@ sections:
           Callers (scripts, CI/CD pipelines) must be able to detect failure conditions
           programmatically via the process exit code.
         tests:
-          - CliSubsystem_VersionFlow_ContextAndProgram_DisplaysVersionAndExits
+          - CliSubsystem_InvalidArgs_ContextAndProgram_RejectsUnknownArgumentsAndExitsNonZero

--- a/docs/reqstream/template-dot-net-tool/self-test/self-test.yaml
+++ b/docs/reqstream/template-dot-net-tool/self-test/self-test.yaml
@@ -20,10 +20,7 @@ sections:
           summary, enabling quality assurance teams to obtain tool qualification evidence
           without requiring a separate test harness.
         tests:
-          - Validation_Run_NullContext_ThrowsArgumentNullException
-          - Validation_Run_WithSilentContext_PrintsSummary
-          - Validation_Run_WithSilentContext_ExitCodeIsZero
-          - IntegrationTest_ValidateFlag_RunsValidation
+          - SelfTestSubsystem_ValidationWorkflow_NoResultFiles_CompletesSuccessfully
 
       - id: Template-SelfTest-ResultsOutput
         title: The tool shall write self-validation results to a standard test result file when --results is provided.
@@ -34,7 +31,6 @@ sections:
           directly into pipeline tooling and traceability reports without additional
           conversion steps, satisfying audit trail requirements.
         tests:
-          - Validation_Run_WithTrxResultsFile_WritesTrxFile
-          - Validation_Run_WithXmlResultsFile_WritesXmlFile
-          - IntegrationTest_ValidateWithResults_GeneratesTrxFile
-          - IntegrationTest_ValidateWithResults_GeneratesJUnitFile
+          - SelfTestSubsystem_ValidationWorkflow_WithTrxFile_GeneratesResults
+          - SelfTestSubsystem_ValidationWorkflow_WithJUnitFile_GeneratesResults
+          - SelfTestSubsystem_ValidationWorkflow_WithBothResultFiles_GeneratesBothResults

--- a/docs/reqstream/template-dot-net-tool/utilities/utilities.yaml
+++ b/docs/reqstream/template-dot-net-tool/utilities/utilities.yaml
@@ -20,4 +20,4 @@ sections:
         tests:
           - UtilitiesSubsystem_PathResolutionWorkflow_ValidPaths_ResolvesCorrectly
           - UtilitiesSubsystem_DirectoryCreationWorkflow_ValidPaths_CreatesDirectories
-          - UtilitiesSubsystem_FilePathValidationWorkflow_VariousPaths_ValidatesCorrectly
+          - UtilitiesSubsystem_PathTraversalValidation_DangerousPaths_ThrowsException

--- a/docs/reqstream/template-dot-net-tool/utilities/utilities.yaml
+++ b/docs/reqstream/template-dot-net-tool/utilities/utilities.yaml
@@ -18,7 +18,6 @@ sections:
           file system access. This requirement captures the subsystem-level safety guarantee
           that all consumers of the Utilities subsystem can rely upon.
         tests:
-          - PathHelpers_SafePathCombine_ValidPaths_CombinesCorrectly
-          - PathHelpers_SafePathCombine_PathTraversalWithDoubleDots_ThrowsArgumentException
-          - PathHelpers_SafePathCombine_AbsolutePath_ThrowsArgumentException
-          - PathHelpers_SafePathCombine_NestedPaths_CombinesCorrectly
+          - UtilitiesSubsystem_PathResolutionWorkflow_ValidPaths_ResolvesCorrectly
+          - UtilitiesSubsystem_DirectoryCreationWorkflow_ValidPaths_CreatesDirectories
+          - UtilitiesSubsystem_FilePathValidationWorkflow_VariousPaths_ValidatesCorrectly

--- a/test/DemaConsulting.TemplateDotNetTool.Tests/Cli/CliSubsystemTests.cs
+++ b/test/DemaConsulting.TemplateDotNetTool.Tests/Cli/CliSubsystemTests.cs
@@ -35,16 +35,28 @@ public class CliSubsystemTests
     [TestMethod]
     public void CliSubsystem_VersionFlow_ContextAndProgram_DisplaysVersionAndExits()
     {
-        // Arrange: command line arguments with version flag
+        // Arrange: command line arguments with version flag; capture console output
         var args = new[] { "--version" };
+        var originalOut = Console.Out;
+        using var capturedOut = new StringWriter();
 
-        // Act: create context and run program logic
-        using var context = Context.Create(args);
-        Program.Run(context);
+        try
+        {
+            Console.SetOut(capturedOut);
 
-        // Assert: version flag is parsed and exit code is success
-        Assert.IsTrue(context.Version, "Context should parse version flag");
-        Assert.AreEqual(0, context.ExitCode, "Context should have success exit code");
+            // Act: create context and run program logic
+            using var context = Context.Create(args);
+            Program.Run(context);
+
+            // Assert: version flag is parsed, version text is displayed, and exit code is success
+            Assert.IsTrue(context.Version, "Context should parse version flag");
+            Assert.AreEqual(0, context.ExitCode, "Context should have success exit code");
+            StringAssert.Contains(capturedOut.ToString(), Program.Version, "Console output should contain the program version");
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+        }
     }
 
     /// <summary>
@@ -53,16 +65,94 @@ public class CliSubsystemTests
     [TestMethod]
     public void CliSubsystem_HelpFlow_ContextAndProgram_DisplaysHelpAndExits()
     {
-        // Arrange: command line arguments with help flag
+        // Arrange: command line arguments with help flag; capture console output
         var args = new[] { "--help" };
+        var originalOut = Console.Out;
+        using var capturedOut = new StringWriter();
 
-        // Act: create context and run program logic
-        using var context = Context.Create(args);
-        Program.Run(context);
+        try
+        {
+            Console.SetOut(capturedOut);
 
-        // Assert: help flag is parsed and exit code is success
-        Assert.IsTrue(context.Help, "Context should parse help flag");
-        Assert.AreEqual(0, context.ExitCode, "Context should have success exit code");
+            // Act: create context and run program logic
+            using var context = Context.Create(args);
+            Program.Run(context);
+
+            // Assert: help flag is parsed, usage text is displayed, and exit code is success
+            Assert.IsTrue(context.Help, "Context should parse help flag");
+            Assert.AreEqual(0, context.ExitCode, "Context should have success exit code");
+            var output = capturedOut.ToString();
+            StringAssert.Contains(output, "Usage:", "Console output should contain usage information");
+            StringAssert.Contains(output, "Options:", "Console output should contain options information");
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+        }
+    }
+
+    /// <summary>
+    ///     Test that Context and Program work together to handle the -? short help flag.
+    /// </summary>
+    [TestMethod]
+    public void CliSubsystem_HelpFlow_ContextAndProgram_DisplaysHelpAndExits_WithShortQuestionFlag()
+    {
+        // Arrange: command line arguments with -? short help flag; capture console output
+        var args = new[] { "-?" };
+        var originalOut = Console.Out;
+        using var capturedOut = new StringWriter();
+
+        try
+        {
+            Console.SetOut(capturedOut);
+
+            // Act: create context and run program logic
+            using var context = Context.Create(args);
+            Program.Run(context);
+
+            // Assert: help flag is parsed, usage text is displayed, and exit code is success
+            Assert.IsTrue(context.Help, "Context should parse -? flag as help");
+            Assert.AreEqual(0, context.ExitCode, "Context should have success exit code");
+            var output = capturedOut.ToString();
+            StringAssert.Contains(output, "Usage:", "Console output should contain usage information");
+            StringAssert.Contains(output, "Options:", "Console output should contain options information");
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+        }
+    }
+
+    /// <summary>
+    ///     Test that Context and Program work together to handle the -h short help flag.
+    /// </summary>
+    [TestMethod]
+    public void CliSubsystem_HelpFlow_ContextAndProgram_DisplaysHelpAndExits_WithShortHFlag()
+    {
+        // Arrange: command line arguments with -h short help flag; capture console output
+        var args = new[] { "-h" };
+        var originalOut = Console.Out;
+        using var capturedOut = new StringWriter();
+
+        try
+        {
+            Console.SetOut(capturedOut);
+
+            // Act: create context and run program logic
+            using var context = Context.Create(args);
+            Program.Run(context);
+
+            // Assert: help flag is parsed, usage text is displayed, and exit code is success
+            Assert.IsTrue(context.Help, "Context should parse -h flag as help");
+            Assert.AreEqual(0, context.ExitCode, "Context should have success exit code");
+            var output = capturedOut.ToString();
+            StringAssert.Contains(output, "Usage:", "Console output should contain usage information");
+            StringAssert.Contains(output, "Options:", "Console output should contain options information");
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+        }
     }
 
     /// <summary>

--- a/test/DemaConsulting.TemplateDotNetTool.Tests/Cli/CliSubsystemTests.cs
+++ b/test/DemaConsulting.TemplateDotNetTool.Tests/Cli/CliSubsystemTests.cs
@@ -1,0 +1,103 @@
+// Copyright (c) DEMA Consulting
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using DemaConsulting.TemplateDotNetTool.Cli;
+
+namespace DemaConsulting.TemplateDotNetTool.Tests;
+
+/// <summary>
+///     Subsystem tests for the CLI subsystem covering Context and Program integration.
+/// </summary>
+[TestClass]
+public class CliSubsystemTests
+{
+    /// <summary>
+    ///     Test that Context and Program work together to handle version flag workflow.
+    /// </summary>
+    [TestMethod]
+    public void CliSubsystem_VersionFlow_ContextAndProgram_DisplaysVersionAndExits()
+    {
+        // Arrange: command line arguments with version flag
+        var args = new[] { "--version" };
+
+        // Act: create context and run program logic
+        using var context = Context.Create(args);
+        Program.Run(context);
+
+        // Assert: version flag is parsed and exit code is success
+        Assert.IsTrue(context.Version, "Context should parse version flag");
+        Assert.AreEqual(0, context.ExitCode, "Context should have success exit code");
+    }
+
+    /// <summary>
+    ///     Test that Context and Program work together to handle help flag workflow.
+    /// </summary>
+    [TestMethod]
+    public void CliSubsystem_HelpFlow_ContextAndProgram_DisplaysHelpAndExits()
+    {
+        // Arrange: command line arguments with help flag
+        var args = new[] { "--help" };
+
+        // Act: create context and run program logic
+        using var context = Context.Create(args);
+        Program.Run(context);
+
+        // Assert: help flag is parsed and exit code is success
+        Assert.IsTrue(context.Help, "Context should parse help flag");
+        Assert.AreEqual(0, context.ExitCode, "Context should have success exit code");
+    }
+
+    /// <summary>
+    ///     Test that Context and Program work together to handle validation flag workflow.
+    /// </summary>
+    [TestMethod]
+    public void CliSubsystem_ValidateFlow_ContextAndProgram_RunsValidationAndExits()
+    {
+        // Arrange: command line arguments with validate flag
+        var args = new[] { "--validate" };
+
+        // Act: create context and run program logic
+        using var context = Context.Create(args);
+        Program.Run(context);
+
+        // Assert: validate flag is parsed and exit code is success
+        Assert.IsTrue(context.Validate, "Context should parse validate flag");
+        Assert.AreEqual(0, context.ExitCode, "Context should have success exit code");
+    }
+
+    /// <summary>
+    ///     Test that Context and Program work together to handle silent flag workflow.
+    /// </summary>
+    [TestMethod]
+    public void CliSubsystem_SilentFlow_ContextAndProgram_SuppressesOutput()
+    {
+        // Arrange: command line arguments with version and silent flags
+        var args = new[] { "--version", "--silent" };
+
+        // Act: create context and run program logic
+        using var context = Context.Create(args);
+        Program.Run(context);
+
+        // Assert: silent flag is parsed and exit code is success
+        Assert.IsTrue(context.Silent, "Context should parse silent flag");
+        Assert.AreEqual(0, context.ExitCode, "Context should have success exit code");
+    }
+}
+

--- a/test/DemaConsulting.TemplateDotNetTool.Tests/Cli/CliSubsystemTests.cs
+++ b/test/DemaConsulting.TemplateDotNetTool.Tests/Cli/CliSubsystemTests.cs
@@ -99,5 +99,117 @@ public class CliSubsystemTests
         Assert.IsTrue(context.Silent, "Context should parse silent flag");
         Assert.AreEqual(0, context.ExitCode, "Context should have success exit code");
     }
-}
 
+    /// <summary>
+    ///     Test that Context and Program work together to handle results flag workflow.
+    /// </summary>
+    [TestMethod]
+    public void CliSubsystem_ResultsFlow_ContextAndProgram_WritesResultsFile()
+    {
+        // Arrange: temporary results file path and validation command with results output
+        var tempDir = Path.GetTempPath();
+        var resultsFile = Path.Combine(tempDir, $"cli_test_{Guid.NewGuid()}.trx");
+        var args = new[] { "--validate", "--silent", "--results", resultsFile };
+
+        try
+        {
+            // Act: create context and run program logic
+            using var context = Context.Create(args);
+            Program.Run(context);
+
+            // Assert: results flag is parsed, validation runs, and results file is written
+            Assert.AreEqual(resultsFile, context.ResultsFile, "Context should parse results file path");
+            Assert.AreEqual(0, context.ExitCode, "Program should complete successfully");
+            Assert.IsTrue(File.Exists(resultsFile), "Results file should be written to specified path");
+        }
+        finally
+        {
+            // Cleanup
+            if (File.Exists(resultsFile))
+            {
+                File.Delete(resultsFile);
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Test that Context and Program work together to handle log flag workflow.
+    /// </summary>
+    [TestMethod]
+    public void CliSubsystem_LogFlow_ContextAndProgram_WritesLogFile()
+    {
+        // Arrange: temporary log file path and version command with log output
+        var tempDir = Path.GetTempPath();
+        var logFile = Path.Combine(tempDir, $"cli_test_{Guid.NewGuid()}.log");
+        var args = new[] { "--version", "--log", logFile };
+
+        try
+        {
+            // Act: create context and run program logic
+            using (var context = Context.Create(args))
+            {
+                Program.Run(context);
+
+                // Assert: version flag is parsed and exit code is success
+                Assert.IsTrue(context.Version, "Context should parse version flag");
+                Assert.AreEqual(0, context.ExitCode, "Program should complete successfully");
+            }
+
+            // Assert: log file is written with version output
+            Assert.IsTrue(File.Exists(logFile), "Log file should be created at specified path");
+            var logContent = File.ReadAllText(logFile);
+            Assert.IsFalse(string.IsNullOrWhiteSpace(logContent), "Log file should contain version output");
+        }
+        finally
+        {
+            // Cleanup
+            if (File.Exists(logFile))
+            {
+                File.Delete(logFile);
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Test that Context rejects unknown arguments and would cause a non-zero exit code.
+    /// </summary>
+    [TestMethod]
+    public void CliSubsystem_InvalidArgs_ContextAndProgram_RejectsUnknownArgumentsAndExitsNonZero()
+    {
+        // Arrange: unknown command-line argument
+        var args = new[] { "--unknown-flag" };
+
+        // Act & Assert: unknown arguments throw an ArgumentException (causing non-zero exit in Main)
+        var exception = Assert.Throws<ArgumentException>(() => Context.Create(args));
+        Assert.IsNotNull(exception, "Context.Create should throw for unknown arguments");
+        StringAssert.Contains(exception.Message, "--unknown-flag");
+    }
+
+    /// <summary>
+    ///     Test that Context writes error messages to stderr.
+    /// </summary>
+    [TestMethod]
+    public void CliSubsystem_ErrorOutput_ContextAndProgram_WritesErrorToStderr()
+    {
+        // Arrange: redirect stderr to capture error output
+        var originalError = Console.Error;
+        try
+        {
+            using var errWriter = new StringWriter();
+            Console.SetError(errWriter);
+            using var context = Context.Create([]);
+
+            // Act: write an error message through the context
+            context.WriteError("Test error message");
+
+            // Assert: error is written to stderr and exit code reflects failure
+            var errorOutput = errWriter.ToString();
+            StringAssert.Contains(errorOutput, "Test error message");
+            Assert.AreEqual(1, context.ExitCode, "Exit code should be non-zero after error");
+        }
+        finally
+        {
+            Console.SetError(originalError);
+        }
+    }
+}

--- a/test/DemaConsulting.TemplateDotNetTool.Tests/Cli/CliSubsystemTests.cs
+++ b/test/DemaConsulting.TemplateDotNetTool.Tests/Cli/CliSubsystemTests.cs
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using System.Reflection;
 using DemaConsulting.TemplateDotNetTool.Cli;
 
 namespace DemaConsulting.TemplateDotNetTool.Tests;
@@ -88,16 +89,33 @@ public class CliSubsystemTests
     [TestMethod]
     public void CliSubsystem_SilentFlow_ContextAndProgram_SuppressesOutput()
     {
-        // Arrange: command line arguments with version and silent flags
+        // Arrange: command line arguments with version and silent flags; capture console streams
         var args = new[] { "--version", "--silent" };
+        var originalOut = Console.Out;
+        var originalError = Console.Error;
+        using var capturedOut = new StringWriter();
+        using var capturedError = new StringWriter();
 
-        // Act: create context and run program logic
-        using var context = Context.Create(args);
-        Program.Run(context);
+        try
+        {
+            Console.SetOut(capturedOut);
+            Console.SetError(capturedError);
 
-        // Assert: silent flag is parsed and exit code is success
-        Assert.IsTrue(context.Silent, "Context should parse silent flag");
-        Assert.AreEqual(0, context.ExitCode, "Context should have success exit code");
+            // Act: create context and run program logic
+            using var context = Context.Create(args);
+            Program.Run(context);
+
+            // Assert: silent flag is parsed, exit code is success, and no console output is produced
+            Assert.IsTrue(context.Silent, "Context should parse silent flag");
+            Assert.AreEqual(0, context.ExitCode, "Context should have success exit code");
+            Assert.AreEqual(string.Empty, capturedOut.ToString(), "Program should not write to stdout when --silent is set");
+            Assert.AreEqual(string.Empty, capturedError.ToString(), "Program should not write to stderr when --silent is set");
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+            Console.SetError(originalError);
+        }
     }
 
     /// <summary>
@@ -171,18 +189,42 @@ public class CliSubsystemTests
     }
 
     /// <summary>
-    ///     Test that Context rejects unknown arguments and would cause a non-zero exit code.
+    ///     Test that Program rejects unknown arguments, writes an error to stderr, and exits non-zero.
     /// </summary>
     [TestMethod]
     public void CliSubsystem_InvalidArgs_ContextAndProgram_RejectsUnknownArgumentsAndExitsNonZero()
     {
-        // Arrange: unknown command-line argument
+        // Arrange: unknown command-line argument and reflection to access private Program.Main
         var args = new[] { "--unknown-flag" };
+        var mainMethod = typeof(Program).GetMethod(
+            "Main",
+            BindingFlags.Static | BindingFlags.NonPublic,
+            binder: null,
+            types: [typeof(string[])],
+            modifiers: null);
 
-        // Act & Assert: unknown arguments throw an ArgumentException (causing non-zero exit in Main)
-        var exception = Assert.Throws<ArgumentException>(() => Context.Create(args));
-        Assert.IsNotNull(exception, "Context.Create should throw for unknown arguments");
-        StringAssert.Contains(exception.Message, "--unknown-flag");
+        Assert.IsNotNull(mainMethod, "Program.Main(string[]) should exist");
+
+        var originalError = Console.Error;
+        try
+        {
+            using var errWriter = new StringWriter();
+            Console.SetError(errWriter);
+
+            // Act: invoke the actual CLI entry point with an unknown flag
+            var result = mainMethod.Invoke(null, [args]);
+
+            // Assert: invalid arguments produce a non-zero exit code and an error on stderr
+            Assert.IsNotNull(result, "Program.Main should return an exit code");
+            Assert.AreEqual(1, Convert.ToInt32(result), "Unknown arguments should cause exit code 1");
+            var errorOutput = errWriter.ToString();
+            Assert.IsFalse(string.IsNullOrWhiteSpace(errorOutput), "Program should write an error to stderr for unknown arguments");
+            StringAssert.Contains(errorOutput, "--unknown-flag");
+        }
+        finally
+        {
+            Console.SetError(originalError);
+        }
     }
 
     /// <summary>

--- a/test/DemaConsulting.TemplateDotNetTool.Tests/Cli/ContextTests.cs
+++ b/test/DemaConsulting.TemplateDotNetTool.Tests/Cli/ContextTests.cs
@@ -34,10 +34,10 @@ public class ContextTests
     [TestMethod]
     public void Context_Create_NoArguments_ReturnsDefaultContext()
     {
-        // Act
+        // Act: execute the operation being tested
         using var context = Context.Create([]);
 
-        // Assert
+        // Assert: verify expected behavior
         Assert.IsFalse(context.Version);
         Assert.IsFalse(context.Help);
         Assert.IsFalse(context.Silent);
@@ -52,10 +52,10 @@ public class ContextTests
     [TestMethod]
     public void Context_Create_VersionFlag_SetsVersionTrue()
     {
-        // Act
+        // Act: execute the operation being tested
         using var context = Context.Create(["--version"]);
 
-        // Assert
+        // Assert: verify expected behavior
         Assert.IsTrue(context.Version);
         Assert.IsFalse(context.Help);
         Assert.AreEqual(0, context.ExitCode);
@@ -67,10 +67,10 @@ public class ContextTests
     [TestMethod]
     public void Context_Create_ShortVersionFlag_SetsVersionTrue()
     {
-        // Act
+        // Act: execute the operation being tested
         using var context = Context.Create(["-v"]);
 
-        // Assert
+        // Assert: verify expected behavior
         Assert.IsTrue(context.Version);
         Assert.IsFalse(context.Help);
         Assert.AreEqual(0, context.ExitCode);
@@ -82,10 +82,10 @@ public class ContextTests
     [TestMethod]
     public void Context_Create_HelpFlag_SetsHelpTrue()
     {
-        // Act
+        // Act: execute the operation being tested
         using var context = Context.Create(["--help"]);
 
-        // Assert
+        // Assert: verify expected behavior
         Assert.IsFalse(context.Version);
         Assert.IsTrue(context.Help);
         Assert.AreEqual(0, context.ExitCode);
@@ -97,10 +97,10 @@ public class ContextTests
     [TestMethod]
     public void Context_Create_ShortHelpFlag_H_SetsHelpTrue()
     {
-        // Act
+        // Act: execute the operation being tested
         using var context = Context.Create(["-h"]);
 
-        // Assert
+        // Assert: verify expected behavior
         Assert.IsFalse(context.Version);
         Assert.IsTrue(context.Help);
         Assert.AreEqual(0, context.ExitCode);
@@ -112,10 +112,10 @@ public class ContextTests
     [TestMethod]
     public void Context_Create_ShortHelpFlag_Question_SetsHelpTrue()
     {
-        // Act
+        // Act: execute the operation being tested
         using var context = Context.Create(["-?"]);
 
-        // Assert
+        // Assert: verify expected behavior
         Assert.IsFalse(context.Version);
         Assert.IsTrue(context.Help);
         Assert.AreEqual(0, context.ExitCode);
@@ -127,10 +127,10 @@ public class ContextTests
     [TestMethod]
     public void Context_Create_SilentFlag_SetsSilentTrue()
     {
-        // Act
+        // Act: execute the operation being tested
         using var context = Context.Create(["--silent"]);
 
-        // Assert
+        // Assert: verify expected behavior
         Assert.IsTrue(context.Silent);
         Assert.AreEqual(0, context.ExitCode);
     }
@@ -141,10 +141,10 @@ public class ContextTests
     [TestMethod]
     public void Context_Create_ValidateFlag_SetsValidateTrue()
     {
-        // Act
+        // Act: execute the operation being tested
         using var context = Context.Create(["--validate"]);
 
-        // Assert
+        // Assert: verify expected behavior
         Assert.IsTrue(context.Validate);
         Assert.AreEqual(0, context.ExitCode);
     }
@@ -155,10 +155,10 @@ public class ContextTests
     [TestMethod]
     public void Context_Create_ResultsFlag_SetsResultsFile()
     {
-        // Act
+        // Act: execute the operation being tested
         using var context = Context.Create(["--results", "test.trx"]);
 
-        // Assert
+        // Assert: verify expected behavior
         Assert.AreEqual("test.trx", context.ResultsFile);
         Assert.AreEqual(0, context.ExitCode);
     }
@@ -169,18 +169,18 @@ public class ContextTests
     [TestMethod]
     public void Context_Create_LogFlag_OpensLogFile()
     {
-        // Arrange
+        // Arrange: setup test conditions
         var logFile = Path.GetTempFileName();
         try
         {
-            // Act
+            // Act: execute the operation being tested
             using (var context = Context.Create(["--log", logFile]))
             {
                 context.WriteLine("Test message");
                 Assert.AreEqual(0, context.ExitCode);
             }
 
-            // Assert
+            // Assert: verify expected behavior
             // Verify log file was written
             Assert.IsTrue(File.Exists(logFile));
             var logContent = File.ReadAllText(logFile);
@@ -234,7 +234,7 @@ public class ContextTests
     [TestMethod]
     public void Context_WriteLine_NotSilent_WritesToConsole()
     {
-        // Arrange
+        // Arrange: setup test conditions
         var originalOut = Console.Out;
         try
         {
@@ -242,10 +242,10 @@ public class ContextTests
             Console.SetOut(outWriter);
             using var context = Context.Create([]);
 
-            // Act
+            // Act: execute the operation being tested
             context.WriteLine("Test message");
 
-            // Assert
+            // Assert: verify expected behavior
             var output = outWriter.ToString();
             Assert.Contains("Test message", output);
         }
@@ -261,7 +261,7 @@ public class ContextTests
     [TestMethod]
     public void Context_WriteLine_Silent_DoesNotWriteToConsole()
     {
-        // Arrange
+        // Arrange: setup test conditions
         var originalOut = Console.Out;
         try
         {
@@ -269,10 +269,10 @@ public class ContextTests
             Console.SetOut(outWriter);
             using var context = Context.Create(["--silent"]);
 
-            // Act
+            // Act: execute the operation being tested
             context.WriteLine("Test message");
 
-            // Assert
+            // Assert: verify expected behavior
             var output = outWriter.ToString();
             Assert.DoesNotContain("Test message", output);
         }
@@ -288,7 +288,7 @@ public class ContextTests
     [TestMethod]
     public void Context_WriteError_Silent_DoesNotWriteToConsole()
     {
-        // Arrange
+        // Arrange: setup test conditions
         var originalError = Console.Error;
         try
         {
@@ -296,7 +296,7 @@ public class ContextTests
             Console.SetError(errWriter);
             using var context = Context.Create(["--silent"]);
 
-            // Act
+            // Act: execute the operation being tested
             context.WriteError("Test error message");
 
             // Assert - error output should be suppressed in silent mode
@@ -315,7 +315,7 @@ public class ContextTests
     [TestMethod]
     public void Context_WriteError_SetsErrorExitCode()
     {
-        // Arrange
+        // Arrange: setup test conditions
         var originalError = Console.Error;
         try
         {
@@ -323,10 +323,10 @@ public class ContextTests
             Console.SetError(errWriter);
             using var context = Context.Create([]);
 
-            // Act
+            // Act: execute the operation being tested
             context.WriteError("Test error message");
 
-            // Assert
+            // Assert: verify expected behavior
             Assert.AreEqual(1, context.ExitCode);
         }
         finally
@@ -341,7 +341,7 @@ public class ContextTests
     [TestMethod]
     public void Context_WriteError_NotSilent_WritesToConsole()
     {
-        // Arrange
+        // Arrange: setup test conditions
         var originalError = Console.Error;
         try
         {
@@ -349,10 +349,10 @@ public class ContextTests
             Console.SetError(errWriter);
             using var context = Context.Create([]);
 
-            // Act
+            // Act: execute the operation being tested
             context.WriteError("Test error message");
 
-            // Assert
+            // Assert: verify expected behavior
             var output = errWriter.ToString();
             Assert.Contains("Test error message", output);
         }
@@ -368,7 +368,7 @@ public class ContextTests
     [TestMethod]
     public void Context_WriteError_WritesToLogFile()
     {
-        // Arrange
+        // Arrange: setup test conditions
         var logFile = Path.GetTempFileName();
         try
         {
@@ -393,4 +393,5 @@ public class ContextTests
         }
     }
 }
+
 

--- a/test/DemaConsulting.TemplateDotNetTool.Tests/IntegrationTests.cs
+++ b/test/DemaConsulting.TemplateDotNetTool.Tests/IntegrationTests.cs
@@ -50,14 +50,14 @@ public class IntegrationTests
     [TestMethod]
     public void IntegrationTest_VersionFlag_OutputsVersion()
     {
-        // Act
+        // Act: run the tool with version flag
         var exitCode = Runner.Run(
             out var output,
             "dotnet",
             _dllPath,
             "--version");
 
-        // Assert
+        // Assert: verify version output and success exit code
         Assert.AreEqual(0, exitCode);
         Assert.IsFalse(string.IsNullOrWhiteSpace(output));
         Assert.DoesNotContain("Error", output);
@@ -70,14 +70,14 @@ public class IntegrationTests
     [TestMethod]
     public void IntegrationTest_HelpFlag_OutputsUsageInformation()
     {
-        // Act
+        // Act: execute the operation being tested
         var exitCode = Runner.Run(
             out var output,
             "dotnet",
             _dllPath,
             "--help");
 
-        // Assert
+        // Assert: verify expected behavior
         Assert.AreEqual(0, exitCode);
         Assert.Contains("Usage:", output);
         Assert.Contains("Options:", output);
@@ -90,14 +90,14 @@ public class IntegrationTests
     [TestMethod]
     public void IntegrationTest_ValidateFlag_RunsValidation()
     {
-        // Act
+        // Act: execute the operation being tested
         var exitCode = Runner.Run(
             out var output,
             "dotnet",
             _dllPath,
             "--validate");
 
-        // Assert
+        // Assert: verify expected behavior
         Assert.AreEqual(0, exitCode);
         Assert.Contains("Total Tests:", output);
         Assert.Contains("Passed:", output);
@@ -109,12 +109,12 @@ public class IntegrationTests
     [TestMethod]
     public void IntegrationTest_ValidateWithResults_GeneratesTrxFile()
     {
-        // Arrange
+        // Arrange: setup test conditions
         var resultsFile = Path.Combine(Path.GetTempPath(), $"integration_test_{Guid.NewGuid()}.trx");
 
         try
         {
-            // Act
+            // Act: execute the operation being tested
             var exitCode = Runner.Run(
                 out var _,
                 "dotnet",
@@ -123,7 +123,7 @@ public class IntegrationTests
                 "--results",
                 resultsFile);
 
-            // Assert
+            // Assert: verify expected behavior
             Assert.AreEqual(0, exitCode);
             Assert.IsTrue(File.Exists(resultsFile), "Results file was not created");
 
@@ -146,14 +146,14 @@ public class IntegrationTests
     [TestMethod]
     public void IntegrationTest_SilentFlag_SuppressesOutput()
     {
-        // Act
+        // Act: execute the operation being tested
         var exitCode = Runner.Run(
             out var _,
             "dotnet",
             _dllPath,
             "--silent");
 
-        // Assert
+        // Assert: verify expected behavior
         Assert.AreEqual(0, exitCode);
 
         // Output check removed since silent mode may still produce some output
@@ -165,12 +165,12 @@ public class IntegrationTests
     [TestMethod]
     public void IntegrationTest_LogFlag_WritesOutputToFile()
     {
-        // Arrange
+        // Arrange: setup test conditions
         var logFile = Path.GetTempFileName();
 
         try
         {
-            // Act
+            // Act: execute the operation being tested
             var exitCode = Runner.Run(
                 out var _,
                 "dotnet",
@@ -178,7 +178,7 @@ public class IntegrationTests
                 "--log",
                 logFile);
 
-            // Assert
+            // Assert: verify expected behavior
             Assert.AreEqual(0, exitCode);
             Assert.IsTrue(File.Exists(logFile), "Log file was not created");
 
@@ -200,12 +200,12 @@ public class IntegrationTests
     [TestMethod]
     public void IntegrationTest_ValidateWithResults_GeneratesJUnitFile()
     {
-        // Arrange
+        // Arrange: setup test conditions
         var resultsFile = Path.Combine(Path.GetTempPath(), $"integration_test_{Guid.NewGuid()}.xml");
 
         try
         {
-            // Act
+            // Act: execute the operation being tested
             var exitCode = Runner.Run(
                 out var _,
                 "dotnet",
@@ -214,7 +214,7 @@ public class IntegrationTests
                 "--results",
                 resultsFile);
 
-            // Assert
+            // Assert: verify expected behavior
             Assert.AreEqual(0, exitCode);
             Assert.IsTrue(File.Exists(resultsFile), "Results file was not created");
 
@@ -236,15 +236,16 @@ public class IntegrationTests
     [TestMethod]
     public void IntegrationTest_UnknownArgument_ReturnsError()
     {
-        // Act
+        // Act: execute the operation being tested
         var exitCode = Runner.Run(
             out var output,
             "dotnet",
             _dllPath,
             "--unknown");
 
-        // Assert
+        // Assert: verify expected behavior
         Assert.AreNotEqual(0, exitCode);
         Assert.Contains("Error", output);
     }
 }
+

--- a/test/DemaConsulting.TemplateDotNetTool.Tests/ProgramTests.cs
+++ b/test/DemaConsulting.TemplateDotNetTool.Tests/ProgramTests.cs
@@ -34,7 +34,7 @@ public class ProgramTests
     [TestMethod]
     public void Program_Run_WithVersionFlag_DisplaysVersionOnly()
     {
-        // Arrange
+        // Arrange: setup test conditions
         var originalOut = Console.Out;
         try
         {
@@ -42,10 +42,10 @@ public class ProgramTests
             Console.SetOut(outWriter);
             using var context = Context.Create(["--version"]);
 
-            // Act
+            // Act: execute the operation being tested
             Program.Run(context);
 
-            // Assert
+            // Assert: verify expected behavior
             var output = outWriter.ToString();
             Assert.Contains(Program.Version, output);
             Assert.DoesNotContain("Copyright", output);
@@ -63,7 +63,7 @@ public class ProgramTests
     [TestMethod]
     public void Program_Run_WithHelpFlag_DisplaysUsageInformation()
     {
-        // Arrange
+        // Arrange: setup test conditions
         var originalOut = Console.Out;
         try
         {
@@ -71,10 +71,10 @@ public class ProgramTests
             Console.SetOut(outWriter);
             using var context = Context.Create(["--help"]);
 
-            // Act
+            // Act: execute the operation being tested
             Program.Run(context);
 
-            // Assert
+            // Assert: verify expected behavior
             var output = outWriter.ToString();
             Assert.Contains("Usage:", output);
             Assert.Contains("Options:", output);
@@ -93,7 +93,7 @@ public class ProgramTests
     [TestMethod]
     public void Program_Run_WithValidateFlag_RunsValidation()
     {
-        // Arrange
+        // Arrange: setup test conditions
         var originalOut = Console.Out;
         try
         {
@@ -101,10 +101,10 @@ public class ProgramTests
             Console.SetOut(outWriter);
             using var context = Context.Create(["--validate"]);
 
-            // Act
+            // Act: execute the operation being tested
             Program.Run(context);
 
-            // Assert
+            // Assert: verify expected behavior
             var output = outWriter.ToString();
             Assert.Contains("Total Tests:", output);
         }
@@ -120,7 +120,7 @@ public class ProgramTests
     [TestMethod]
     public void Program_Run_NoArguments_DisplaysDefaultBehavior()
     {
-        // Arrange
+        // Arrange: setup test conditions
         var originalOut = Console.Out;
         try
         {
@@ -128,10 +128,10 @@ public class ProgramTests
             Console.SetOut(outWriter);
             using var context = Context.Create([]);
 
-            // Act
+            // Act: execute the operation being tested
             Program.Run(context);
 
-            // Assert
+            // Assert: verify expected behavior
             var output = outWriter.ToString();
             Assert.Contains("Template DotNet Tool version", output);
             Assert.Contains("Copyright", output);
@@ -148,10 +148,11 @@ public class ProgramTests
     [TestMethod]
     public void Program_Version_ReturnsNonEmptyString()
     {
-        // Act
+        // Act: execute the operation being tested
         var version = Program.Version;
 
-        // Assert
+        // Assert: verify expected behavior
         Assert.IsFalse(string.IsNullOrWhiteSpace(version));
     }
 }
+

--- a/test/DemaConsulting.TemplateDotNetTool.Tests/SelfTest/SelfTestSubsystemTests.cs
+++ b/test/DemaConsulting.TemplateDotNetTool.Tests/SelfTest/SelfTestSubsystemTests.cs
@@ -64,10 +64,12 @@ public class SelfTestSubsystemTests
             using var context = Context.Create(args);
             Validation.Run(context);
 
-            // Assert: validation completes and generates TRX file
+            // Assert: validation completes and generates TRX file with standard format
             Assert.IsTrue(context.Validate, "Context should have validate flag set");
             Assert.AreEqual(0, context.ExitCode, "Validation should complete successfully");
             Assert.IsTrue(File.Exists(trxFile), "TRX file should be generated");
+            var trxContent = File.ReadAllText(trxFile);
+            StringAssert.Contains(trxContent, "<TestRun", "TRX file should contain standard TestRun element");
         }
         finally
         {
@@ -96,10 +98,12 @@ public class SelfTestSubsystemTests
             using var context = Context.Create(args);
             Validation.Run(context);
 
-            // Assert: validation completes and generates JUnit XML file
+            // Assert: validation completes and generates JUnit XML file with standard format
             Assert.IsTrue(context.Validate, "Context should have validate flag set");
             Assert.AreEqual(0, context.ExitCode, "Validation should complete successfully");
             Assert.IsTrue(File.Exists(junitFile), "JUnit file should be generated");
+            var junitContent = File.ReadAllText(junitFile);
+            StringAssert.Contains(junitContent, "<testsuites", "JUnit file should contain standard testsuites element");
         }
         finally
         {
@@ -131,10 +135,12 @@ public class SelfTestSubsystemTests
             {
                 Validation.Run(trxContext);
 
-                // Assert: verify validation completed and TRX result file was generated
+                // Assert: verify validation completed and TRX result file was generated with standard format
                 Assert.IsTrue(trxContext.Validate, "Context should have validate flag set for TRX run");
                 Assert.AreEqual(0, trxContext.ExitCode, "Validation should complete successfully for TRX run");
                 Assert.IsTrue(File.Exists(trxFile), "TRX file should be generated");
+                var trxContent = File.ReadAllText(trxFile);
+                StringAssert.Contains(trxContent, "<TestRun", "TRX file should contain standard TestRun element");
             }
 
             // Act: run validation with JUnit XML output
@@ -142,10 +148,12 @@ public class SelfTestSubsystemTests
             {
                 Validation.Run(junitContext);
 
-                // Assert: verify validation completed and JUnit XML result file was generated
+                // Assert: verify validation completed and JUnit XML result file was generated with standard format
                 Assert.IsTrue(junitContext.Validate, "Context should have validate flag set for JUnit run");
                 Assert.AreEqual(0, junitContext.ExitCode, "Validation should complete successfully for JUnit run");
                 Assert.IsTrue(File.Exists(junitFile), "JUnit file should be generated");
+                var junitContent = File.ReadAllText(junitFile);
+                StringAssert.Contains(junitContent, "<testsuites", "JUnit file should contain standard testsuites element");
             }
         }
         finally

--- a/test/DemaConsulting.TemplateDotNetTool.Tests/SelfTest/SelfTestSubsystemTests.cs
+++ b/test/DemaConsulting.TemplateDotNetTool.Tests/SelfTest/SelfTestSubsystemTests.cs
@@ -1,0 +1,146 @@
+// Copyright (c) DEMA Consulting
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using DemaConsulting.TemplateDotNetTool.Cli;
+using DemaConsulting.TemplateDotNetTool.SelfTest;
+
+namespace DemaConsulting.TemplateDotNetTool.Tests;
+
+/// <summary>
+///     Subsystem tests for the SelfTest subsystem covering Validation workflows.
+/// </summary>
+[TestClass]
+public class SelfTestSubsystemTests
+{
+    /// <summary>
+    ///     Test that self-test subsystem can run validation workflow without result files.
+    /// </summary>
+    [TestMethod]
+    public void SelfTestSubsystem_ValidationWorkflow_NoResultFiles_CompletesSuccessfully()
+    {
+        // Arrange: command line arguments for validation in silent mode
+        var args = new[] { "--validate", "--silent" };
+
+        // Act: create context and run validation
+        using var context = Context.Create(args);
+        Validation.Run(context);
+
+        // Assert: validation completes successfully with correct flags set
+        Assert.IsTrue(context.Validate, "Context should have validate flag set");
+        Assert.AreEqual(0, context.ExitCode, "Validation should complete successfully");
+    }
+
+    /// <summary>
+    ///     Test that self-test subsystem can run validation workflow with TRX result file.
+    /// </summary>
+    [TestMethod]
+    public void SelfTestSubsystem_ValidationWorkflow_WithTrxFile_GeneratesResults()
+    {
+        // Arrange: temporary TRX file path and validation command with results output
+        var tempDir = Path.GetTempPath();
+        var trxFile = Path.Combine(tempDir, $"test_{Guid.NewGuid()}.trx");
+        var args = new[] { "--validate", "--silent", "--results", trxFile };
+
+        try
+        {
+            // Act: create context and run validation with TRX output
+            using var context = Context.Create(args);
+            Validation.Run(context);
+
+            // Assert: validation completes and generates TRX file
+            Assert.IsTrue(context.Validate, "Context should have validate flag set");
+            Assert.AreEqual(0, context.ExitCode, "Validation should complete successfully");
+            Assert.IsTrue(File.Exists(trxFile), "TRX file should be generated");
+        }
+        finally
+        {
+            // Cleanup
+            if (File.Exists(trxFile))
+            {
+                File.Delete(trxFile);
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Test that self-test subsystem can run validation workflow with JUnit result file.
+    /// </summary>
+    [TestMethod]
+    public void SelfTestSubsystem_ValidationWorkflow_WithJUnitFile_GeneratesResults()
+    {
+        // Arrange: temporary JUnit XML file path and validation command with results output
+        var tempDir = Path.GetTempPath();
+        var junitFile = Path.Combine(tempDir, $"test_{Guid.NewGuid()}.xml");
+        var args = new[] { "--validate", "--silent", "--results", junitFile };
+
+        try
+        {
+            // Act: create context and run validation with JUnit XML output
+            using var context = Context.Create(args);
+            Validation.Run(context);
+
+            // Assert: validation completes and generates JUnit XML file
+            Assert.IsTrue(context.Validate, "Context should have validate flag set");
+            Assert.AreEqual(0, context.ExitCode, "Validation should complete successfully");
+            Assert.IsTrue(File.Exists(junitFile), "JUnit file should be generated");
+        }
+        finally
+        {
+            // Cleanup
+            if (File.Exists(junitFile))
+            {
+                File.Delete(junitFile);
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Test that self-test subsystem can run validation workflow with both result files.
+    /// </summary>
+    [TestMethod]
+    public void SelfTestSubsystem_ValidationWorkflow_WithBothResultFiles_GeneratesBothResults()
+    {
+        // Arrange: setup validation arguments with TRX result file output
+        var tempDir = Path.GetTempPath();
+        var resultsFile = Path.Combine(tempDir, $"test_{Guid.NewGuid()}.trx");
+        var args = new[] { "--validate", "--silent", "--results", resultsFile };
+
+        try
+        {
+            // Act: create context and run validation with result file output
+            using var context = Context.Create(args);
+            Validation.Run(context);
+
+            // Assert: verify validation completed and result file was generated
+            Assert.IsTrue(context.Validate, "Context should have validate flag set");
+            Assert.AreEqual(0, context.ExitCode, "Validation should complete successfully");
+            Assert.IsTrue(File.Exists(resultsFile), "Results file should be generated");
+        }
+        finally
+        {
+            // Cleanup
+            if (File.Exists(resultsFile))
+            {
+                File.Delete(resultsFile);
+            }
+        }
+    }
+}
+

--- a/test/DemaConsulting.TemplateDotNetTool.Tests/SelfTest/SelfTestSubsystemTests.cs
+++ b/test/DemaConsulting.TemplateDotNetTool.Tests/SelfTest/SelfTestSubsystemTests.cs
@@ -112,33 +112,53 @@ public class SelfTestSubsystemTests
     }
 
     /// <summary>
-    ///     Test that self-test subsystem can run validation workflow with both result files.
+    ///     Test that self-test subsystem can run validation workflow with both result file formats.
     /// </summary>
     [TestMethod]
     public void SelfTestSubsystem_ValidationWorkflow_WithBothResultFiles_GeneratesBothResults()
     {
-        // Arrange: setup validation arguments with TRX result file output
+        // Arrange: setup validation arguments for both TRX and JUnit result file outputs
         var tempDir = Path.GetTempPath();
-        var resultsFile = Path.Combine(tempDir, $"test_{Guid.NewGuid()}.trx");
-        var args = new[] { "--validate", "--silent", "--results", resultsFile };
+        var trxFile = Path.Combine(tempDir, $"test_{Guid.NewGuid()}.trx");
+        var junitFile = Path.Combine(tempDir, $"test_{Guid.NewGuid()}.xml");
+        var trxArgs = new[] { "--validate", "--silent", "--results", trxFile };
+        var junitArgs = new[] { "--validate", "--silent", "--results", junitFile };
 
         try
         {
-            // Act: create context and run validation with result file output
-            using var context = Context.Create(args);
-            Validation.Run(context);
+            // Act: run validation with TRX output
+            using (var trxContext = Context.Create(trxArgs))
+            {
+                Validation.Run(trxContext);
 
-            // Assert: verify validation completed and result file was generated
-            Assert.IsTrue(context.Validate, "Context should have validate flag set");
-            Assert.AreEqual(0, context.ExitCode, "Validation should complete successfully");
-            Assert.IsTrue(File.Exists(resultsFile), "Results file should be generated");
+                // Assert: verify validation completed and TRX result file was generated
+                Assert.IsTrue(trxContext.Validate, "Context should have validate flag set for TRX run");
+                Assert.AreEqual(0, trxContext.ExitCode, "Validation should complete successfully for TRX run");
+                Assert.IsTrue(File.Exists(trxFile), "TRX file should be generated");
+            }
+
+            // Act: run validation with JUnit XML output
+            using (var junitContext = Context.Create(junitArgs))
+            {
+                Validation.Run(junitContext);
+
+                // Assert: verify validation completed and JUnit XML result file was generated
+                Assert.IsTrue(junitContext.Validate, "Context should have validate flag set for JUnit run");
+                Assert.AreEqual(0, junitContext.ExitCode, "Validation should complete successfully for JUnit run");
+                Assert.IsTrue(File.Exists(junitFile), "JUnit file should be generated");
+            }
         }
         finally
         {
             // Cleanup
-            if (File.Exists(resultsFile))
+            if (File.Exists(trxFile))
             {
-                File.Delete(resultsFile);
+                File.Delete(trxFile);
+            }
+
+            if (File.Exists(junitFile))
+            {
+                File.Delete(junitFile);
             }
         }
     }

--- a/test/DemaConsulting.TemplateDotNetTool.Tests/SelfTest/ValidationTests.cs
+++ b/test/DemaConsulting.TemplateDotNetTool.Tests/SelfTest/ValidationTests.cs
@@ -35,11 +35,10 @@ public class ValidationTests
     [TestMethod]
     public void Validation_Run_NullContext_ThrowsArgumentNullException()
     {
-        // Arrange
+        // Arrange: setup test conditions
         // No setup required — null is the input under test.
 
-        // Act & Assert
-        // Proves that Run guards against null context with ArgumentNullException.
+        // Act & Assert: invoke Run with null context and verify ArgumentNullException is thrown
         Assert.ThrowsExactly<ArgumentNullException>(() => Validation.Run(null!));
     }
 
@@ -49,20 +48,17 @@ public class ValidationTests
     [TestMethod]
     public void Validation_Run_WithSilentContext_PrintsSummary()
     {
-        // Arrange
-        // A unique log file path is used to capture output from the silent context.
+        // Arrange: setup unique log file path to capture silent context output
         var logFile = Path.Combine(Path.GetTempPath(), $"validation_test_{Guid.NewGuid()}.log");
         try
         {
             using (var context = Context.Create(["--silent", "--log", logFile]))
             {
-                // Act
+                // Act: run validation with silent context and log file
                 Validation.Run(context);
             }
 
-            // Assert
-            // Proves that Run writes the three expected summary lines to the output.
-            // The context is disposed above so the log file is fully flushed and closed.
+            // Assert: verify summary lines are written to log file
             var logContent = File.ReadAllText(logFile);
             Assert.Contains("Total Tests:", logContent);
             Assert.Contains("Passed:", logContent);
@@ -83,14 +79,13 @@ public class ValidationTests
     [TestMethod]
     public void Validation_Run_WithSilentContext_ExitCodeIsZero()
     {
-        // Arrange
+        // Arrange: create silent context for validation run
         using var context = Context.Create(["--silent"]);
 
-        // Act
+        // Act: run validation with silent context
         Validation.Run(context);
 
-        // Assert
-        // Proves that a successful validation run leaves the exit code at 0.
+        // Assert: verify exit code is zero indicating successful validation
         Assert.AreEqual(0, context.ExitCode);
     }
 
@@ -100,17 +95,16 @@ public class ValidationTests
     [TestMethod]
     public void Validation_Run_WithTrxResultsFile_WritesTrxFile()
     {
-        // Arrange
+        // Arrange: setup TRX file path for test results output
         var trxFile = Path.Combine(Path.GetTempPath(), $"validation_test_{Guid.NewGuid()}.trx");
         try
         {
             using var context = Context.Create(["--silent", "--results", trxFile]);
 
-            // Act
+            // Act: run validation with TRX results output
             Validation.Run(context);
 
-            // Assert
-            // Proves that Run creates a TRX-format file at the requested path.
+            // Assert: verify TRX file is created with expected content
             Assert.IsTrue(File.Exists(trxFile));
             var content = File.ReadAllText(trxFile);
             Assert.Contains("<TestRun", content);
@@ -130,17 +124,16 @@ public class ValidationTests
     [TestMethod]
     public void Validation_Run_WithXmlResultsFile_WritesXmlFile()
     {
-        // Arrange
+        // Arrange: setup XML file path for JUnit results output
         var xmlFile = Path.Combine(Path.GetTempPath(), $"validation_test_{Guid.NewGuid()}.xml");
         try
         {
             using var context = Context.Create(["--silent", "--results", xmlFile]);
 
-            // Act
+            // Act: run validation with XML results output  
             Validation.Run(context);
 
-            // Assert
-            // Proves that Run creates a JUnit-format XML file at the requested path.
+            // Assert: verify XML file is created with JUnit format content
             Assert.IsTrue(File.Exists(xmlFile));
             var content = File.ReadAllText(xmlFile);
             Assert.Contains("<testsuites", content);
@@ -160,17 +153,16 @@ public class ValidationTests
     [TestMethod]
     public void Validation_Run_WithUnsupportedResultsFormat_DoesNotWriteFile()
     {
-        // Arrange
+        // Arrange: setup unsupported file extension for results output
         var jsonFile = Path.Combine(Path.GetTempPath(), $"validation_test_{Guid.NewGuid()}.json");
         try
         {
             using var context = Context.Create(["--silent", "--results", jsonFile]);
 
-            // Act
+            // Act: run validation with unsupported results file extension
             Validation.Run(context);
 
-            // Assert
-            // Proves that Run does not create a file for unsupported formats.
+            // Assert: verify no file is created for unsupported format
             Assert.IsFalse(File.Exists(jsonFile));
         }
         finally
@@ -182,3 +174,4 @@ public class ValidationTests
         }
     }
 }
+

--- a/test/DemaConsulting.TemplateDotNetTool.Tests/Utilities/PathHelpersTests.cs
+++ b/test/DemaConsulting.TemplateDotNetTool.Tests/Utilities/PathHelpersTests.cs
@@ -34,14 +34,14 @@ public class PathHelpersTests
     [TestMethod]
     public void PathHelpers_SafePathCombine_ValidPaths_CombinesCorrectly()
     {
-        // Arrange
+        // Arrange: setup valid base path and relative path for combining
         var basePath = "/home/user/project";
         var relativePath = "subfolder/file.txt";
 
-        // Act
+        // Act: execute the operation being tested
         var result = PathHelpers.SafePathCombine(basePath, relativePath);
 
-        // Assert
+        // Assert: verify expected behavior
         Assert.AreEqual(Path.Combine(basePath, relativePath), result);
     }
 
@@ -51,11 +51,11 @@ public class PathHelpersTests
     [TestMethod]
     public void PathHelpers_SafePathCombine_PathTraversalWithDoubleDots_ThrowsArgumentException()
     {
-        // Arrange
+        // Arrange: setup base path and dangerous path traversal using double dots
         var basePath = "/home/user/project";
         var relativePath = "../etc/passwd";
 
-        // Act & Assert
+        // Act & Assert: attempt path traversal and verify ArgumentException is thrown with expected message
         var exception = Assert.Throws<ArgumentException>(() =>
             PathHelpers.SafePathCombine(basePath, relativePath));
         Assert.Contains("Invalid path component", exception.Message);
@@ -67,11 +67,11 @@ public class PathHelpersTests
     [TestMethod]
     public void PathHelpers_SafePathCombine_DoubleDotsInMiddle_ThrowsArgumentException()
     {
-        // Arrange
+        // Arrange: setup base path and path with double dots in middle for traversal attempt
         var basePath = "/home/user/project";
         var relativePath = "subfolder/../../../etc/passwd";
 
-        // Act & Assert
+        // Act & Assert: attempt path traversal in middle and verify ArgumentException is thrown
         var exception = Assert.Throws<ArgumentException>(() =>
             PathHelpers.SafePathCombine(basePath, relativePath));
         Assert.Contains("Invalid path component", exception.Message);
@@ -83,14 +83,14 @@ public class PathHelpersTests
     [TestMethod]
     public void PathHelpers_SafePathCombine_AbsolutePath_ThrowsArgumentException()
     {
-        // Test Unix absolute path
+        // Arrange & Act & Assert: test Unix absolute path rejection
         var unixBasePath = "/home/user/project";
         var unixRelativePath = "/etc/passwd";
         var unixException = Assert.Throws<ArgumentException>(() =>
             PathHelpers.SafePathCombine(unixBasePath, unixRelativePath));
         Assert.Contains("Invalid path component", unixException.Message);
 
-        // Test Windows absolute path (only on Windows since Windows paths may not be rooted on Unix)
+        // Arrange & Act & Assert: test Windows absolute path rejection (only on Windows)
         if (OperatingSystem.IsWindows())
         {
             var windowsBasePath = "C:\\Users\\project";
@@ -107,14 +107,14 @@ public class PathHelpersTests
     [TestMethod]
     public void PathHelpers_SafePathCombine_CurrentDirectoryReference_CombinesCorrectly()
     {
-        // Arrange
+        // Arrange: setup base path and current directory reference for testing
         var basePath = "/home/user/project";
         var relativePath = "./subfolder/file.txt";
 
-        // Act
+        // Act: execute the operation being tested
         var result = PathHelpers.SafePathCombine(basePath, relativePath);
 
-        // Assert
+        // Assert: verify expected behavior
         Assert.AreEqual(Path.Combine(basePath, relativePath), result);
     }
 
@@ -124,14 +124,14 @@ public class PathHelpersTests
     [TestMethod]
     public void PathHelpers_SafePathCombine_NestedPaths_CombinesCorrectly()
     {
-        // Arrange
+        // Arrange: setup base path and deeply nested relative path
         var basePath = "/home/user/project";
         var relativePath = "level1/level2/level3/file.txt";
 
-        // Act
+        // Act: execute the operation being tested
         var result = PathHelpers.SafePathCombine(basePath, relativePath);
 
-        // Assert
+        // Assert: verify expected behavior
         Assert.AreEqual(Path.Combine(basePath, relativePath), result);
     }
 
@@ -141,14 +141,14 @@ public class PathHelpersTests
     [TestMethod]
     public void PathHelpers_SafePathCombine_EmptyRelativePath_ReturnsBasePath()
     {
-        // Arrange
+        // Arrange: setup base path and empty relative path for testing edge case
         var basePath = "/home/user/project";
         var relativePath = "";
 
-        // Act
+        // Act: execute the operation being tested
         var result = PathHelpers.SafePathCombine(basePath, relativePath);
 
-        // Assert
+        // Assert: verify expected behavior
         Assert.AreEqual(Path.Combine(basePath, relativePath), result);
     }
 
@@ -158,15 +158,16 @@ public class PathHelpersTests
     [TestMethod]
     public void PathHelpers_SafePathCombine_DotDotPrefixedName_CombinesCorrectly()
     {
-        // Arrange - "..data" is a valid in-base directory name that starts with ".." but is not a traversal
+        // Arrange: setup base path and directory name starting with double dots (not traversal)
         var basePath = "/home/user/project";
         var relativePath = "..data/file.txt";
 
-        // Act
+        // Act: execute the operation being tested
         var result = PathHelpers.SafePathCombine(basePath, relativePath);
 
-        // Assert
+        // Assert: verify expected behavior
         Assert.AreEqual(Path.Combine(basePath, relativePath), result);
     }
 }
+
 

--- a/test/DemaConsulting.TemplateDotNetTool.Tests/Utilities/UtilitiesSubsystemTests.cs
+++ b/test/DemaConsulting.TemplateDotNetTool.Tests/Utilities/UtilitiesSubsystemTests.cs
@@ -1,0 +1,122 @@
+// Copyright (c) DEMA Consulting
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using DemaConsulting.TemplateDotNetTool.Utilities;
+
+namespace DemaConsulting.TemplateDotNetTool.Tests;
+
+/// <summary>
+///     Subsystem tests for the Utilities subsystem covering PathHelpers integration workflows.
+/// </summary>
+[TestClass]
+public class UtilitiesSubsystemTests
+{
+    /// <summary>
+    ///     Test that utilities subsystem can handle path combination workflows.
+    /// </summary>
+    [TestMethod]
+    public void UtilitiesSubsystem_PathResolutionWorkflow_ValidPaths_ResolvesCorrectly()
+    {
+        // Arrange: setup base path and test paths for path combination testing
+        var basePath = Path.GetTempPath();
+        var testPaths = new[]
+        {
+            "test.txt",
+            "subdirectory/test.txt",
+            "nested/dir/test.txt"
+        };
+
+        // Act & Assert: combine each test path with base path and verify results are valid absolute paths
+        foreach (var testPath in testPaths)
+        {
+            var combinedPath = PathHelpers.SafePathCombine(basePath, testPath);
+
+            Assert.IsTrue(Path.IsPathFullyQualified(combinedPath),
+                $"SafePathCombine should return absolute path for {testPath}");
+            Assert.IsTrue(combinedPath.StartsWith(basePath),
+                $"Combined path should be within base directory for {testPath}");
+        }
+    }
+
+    /// <summary>
+    ///     Test that utilities subsystem rejects dangerous path traversal attempts.
+    /// </summary>
+    [TestMethod]
+    public void UtilitiesSubsystem_PathTraversalValidation_DangerousPaths_ThrowsException()
+    {
+        // Arrange: setup base path and dangerous path traversal attempts
+        var basePath = Path.GetTempPath();
+        var dangerousPaths = new[]
+        {
+            "../escape.txt",
+            "../../escape.txt",
+            "subdir/../../../escape.txt"
+        };
+
+        // Act & Assert: attempt path traversal and verify exceptions are thrown
+        foreach (var dangerousPath in dangerousPaths)
+        {
+            var exception = Assert.Throws<ArgumentException>(() =>
+                PathHelpers.SafePathCombine(basePath, dangerousPath));
+            Assert.IsNotNull(exception, $"SafePathCombine should reject path traversal: {dangerousPath}");
+        }
+    }
+
+    /// <summary>
+    ///     Test that utilities subsystem can handle directory creation workflows.
+    /// </summary>
+    [TestMethod]
+    public void UtilitiesSubsystem_DirectoryCreationWorkflow_ValidPaths_CreatesDirectories()
+    {
+        // Arrange: setup temp directory and test directory paths for creation testing
+        var tempDir = Path.GetTempPath();
+        var testDirs = new[]
+        {
+            PathHelpers.SafePathCombine(tempDir, $"test_{Guid.NewGuid()}"),
+            PathHelpers.SafePathCombine(tempDir, $"nested_{Guid.NewGuid()}/subdirectory")
+        };
+
+        try
+        {
+            // Act & Assert: create directories and verify they exist
+            foreach (var testDir in testDirs)
+            {
+                var parentDir = Path.GetDirectoryName(testDir) ?? throw new InvalidOperationException("Invalid test directory");
+                Directory.CreateDirectory(parentDir);
+
+                Assert.IsTrue(Directory.Exists(parentDir),
+                    $"Directory should be created successfully: {parentDir}");
+            }
+        }
+        finally
+        {
+            // Cleanup
+            foreach (var testDir in testDirs)
+            {
+                var topLevelDir = Path.Combine(tempDir, Path.GetFileName(testDir.Split(Path.DirectorySeparatorChar)[^2]));
+                if (Directory.Exists(topLevelDir))
+                {
+                    Directory.Delete(topLevelDir, true);
+                }
+            }
+        }
+    }
+}
+

--- a/test/DemaConsulting.TemplateDotNetTool.Tests/Utilities/UtilitiesSubsystemTests.cs
+++ b/test/DemaConsulting.TemplateDotNetTool.Tests/Utilities/UtilitiesSubsystemTests.cs
@@ -47,10 +47,17 @@ public class UtilitiesSubsystemTests
         foreach (var testPath in testPaths)
         {
             var combinedPath = PathHelpers.SafePathCombine(basePath, testPath);
+            var fullBasePath = Path.GetFullPath(basePath);
+            var fullCombinedPath = Path.GetFullPath(combinedPath);
+            var relativePath = Path.GetRelativePath(fullBasePath, fullCombinedPath);
 
             Assert.IsTrue(Path.IsPathFullyQualified(combinedPath),
                 $"SafePathCombine should return absolute path for {testPath}");
-            Assert.IsTrue(combinedPath.StartsWith(basePath),
+            Assert.IsFalse(
+                Path.IsPathRooted(relativePath) ||
+                relativePath.Equals("..", StringComparison.Ordinal) ||
+                relativePath.StartsWith(".." + Path.DirectorySeparatorChar, StringComparison.Ordinal) ||
+                relativePath.StartsWith(".." + Path.AltDirectorySeparatorChar, StringComparison.Ordinal),
                 $"Combined path should be within base directory for {testPath}");
         }
     }
@@ -85,12 +92,14 @@ public class UtilitiesSubsystemTests
     [TestMethod]
     public void UtilitiesSubsystem_DirectoryCreationWorkflow_ValidPaths_CreatesDirectories()
     {
-        // Arrange: setup temp directory and test directory paths for creation testing
+        // Arrange: setup temp directory and unique root directories for cleanup tracking
         var tempDir = Path.GetTempPath();
+        var rootDir1 = PathHelpers.SafePathCombine(tempDir, $"test_{Guid.NewGuid()}");
+        var rootDir2 = PathHelpers.SafePathCombine(tempDir, $"nested_{Guid.NewGuid()}");
         var testDirs = new[]
         {
-            PathHelpers.SafePathCombine(tempDir, $"test_{Guid.NewGuid()}"),
-            PathHelpers.SafePathCombine(tempDir, $"nested_{Guid.NewGuid()}/subdirectory")
+            rootDir1,
+            PathHelpers.SafePathCombine(rootDir2, "subdirectory")
         };
 
         try
@@ -98,22 +107,20 @@ public class UtilitiesSubsystemTests
             // Act & Assert: create directories and verify they exist
             foreach (var testDir in testDirs)
             {
-                var parentDir = Path.GetDirectoryName(testDir) ?? throw new InvalidOperationException("Invalid test directory");
-                Directory.CreateDirectory(parentDir);
+                Directory.CreateDirectory(testDir);
 
-                Assert.IsTrue(Directory.Exists(parentDir),
-                    $"Directory should be created successfully: {parentDir}");
+                Assert.IsTrue(Directory.Exists(testDir),
+                    $"Directory should be created successfully: {testDir}");
             }
         }
         finally
         {
-            // Cleanup
-            foreach (var testDir in testDirs)
+            // Cleanup: delete only the root directories created by this test
+            foreach (var rootDir in new[] { rootDir1, rootDir2 })
             {
-                var topLevelDir = Path.Combine(tempDir, Path.GetFileName(testDir.Split(Path.DirectorySeparatorChar)[^2]));
-                if (Directory.Exists(topLevelDir))
+                if (Directory.Exists(rootDir))
                 {
-                    Directory.Delete(topLevelDir, true);
+                    Directory.Delete(rootDir, true);
                 }
             }
         }


### PR DESCRIPTION
# Pull Request

## Description

Improve agent rules around review-sets, requirements-linking and AAA-comments. Additionally, address review feedback to strengthen test correctness and requirements traceability:

- Fixed fragile path containment assertion in `UtilitiesSubsystemTests` to use `Path.GetRelativePath` instead of `StartsWith`
- Fixed directory creation test to create and assert on the intended leaf directory rather than its parent
- Fixed test cleanup logic to track and delete only the exact root directories created by each test
- Replaced non-existent test reference in `utilities.yaml` with `UtilitiesSubsystem_PathTraversalValidation_DangerousPaths_ThrowsException`
- Rewrote `SelfTestSubsystem_ValidationWorkflow_WithBothResultFiles_GeneratesBothResults` to perform two separate validation runs (one `.trx`, one `.xml`), each asserting its own output file and format signature (`<TestRun` for TRX, `<testsuites` for JUnit)
- Added four new CLI subsystem tests: `ResultsFlow` (verifies `--results` file is written), `LogFlow` (verifies `--log` file is created with content), `InvalidArgs` (uses reflection to invoke `Program.Main` directly, asserting exit code 1 and error on stderr), and `ErrorOutput` (verifies errors are written to stderr with non-zero exit code)
- Strengthened `CliSubsystem_SilentFlow` to capture `Console.Out`/`Console.Error` and assert both are empty when `--silent` is active
- Strengthened `CliSubsystem_InvalidArgs` to call the private `Program.Main` entry point via reflection, asserting actual exit code 1 and descriptive stderr error message
- Strengthened `CliSubsystem_VersionFlow` to capture `Console.Out` and assert `Program.Version` is present in the output
- Strengthened `CliSubsystem_HelpFlow` to capture `Console.Out` and assert `Usage:` and `Options:` markers are present
- Added `CliSubsystem_HelpFlow_ContextAndProgram_DisplaysHelpAndExits_WithShortQuestionFlag` test for the `-?` short flag
- Added `CliSubsystem_HelpFlow_ContextAndProgram_DisplaysHelpAndExits_WithShortHFlag` test for the `-h` short flag
- Updated `cli.yaml` `Template-Cli-Help` and `Template-Cli-Context` linkages to include the two new short-flag tests
- Updated `cli.yaml` requirements linkages for `Template-Cli-Results`, `Template-Cli-Log`, `Template-Cli-ErrorOutput`, `Template-Cli-InvalidArgs`, and `Template-Cli-ExitCode` to reference the new purpose-built tests

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code quality improvement

## Related Issues

N/A

## Pre-Submission Checklist

Before submitting this pull request, ensure you have completed the following:

### Build and Test

- [x] Code builds successfully: `dotnet build --configuration Release`
- [x] All unit tests pass: `dotnet test --configuration Release`
- [x] Self-validation tests pass:
  `dotnet run --project src/DemaConsulting.TemplateDotNetTool --configuration Release --framework net10.0`
  `--no-build -- --validate`
- [x] Code produces zero warnings

### Code Quality

- [x] Code formatting is correct: `dotnet format --verify-no-changes`
- [x] New code has appropriate XML documentation comments
- [ ] Static analyzer warnings have been addressed

### Quality Checks

Please run the following checks before submitting:

- [x] **All linters pass**: `./lint.sh` (Unix/macOS) or `cmd /c lint.bat` / `./lint.bat` (Windows)

### Testing

- [x] Added unit tests for new functionality
- [x] Updated existing tests if behavior changed
- [x] All tests follow the AAA (Arrange, Act, Assert) pattern
- [x] Test coverage is maintained or improved

### Documentation

- [ ] Updated README.md (if applicable)
- [ ] Updated ARCHITECTURE.md (if applicable)
- [ ] Added code examples for new features (if applicable)
- [ ] Updated requirements.yaml (if applicable)

## Additional Notes

N/A